### PR TITLE
MMM-YrNow.js

### DIFF
--- a/MMM-YrNow.js
+++ b/MMM-YrNow.js
@@ -1,6 +1,6 @@
 Module.register('MMM-YrNow', {
 	defaults: {
-        yrApiUrl: "https://www.yr.no/api/v0/locations/id/%s/forecast",
+        yrApiUrl: "https://www.yr.no/api/v0/locations/%s/forecast",
         updateInterval: 10000
 	},
 


### PR DESCRIPTION
Stien er ikke lenger https://www.yr.no/api/v0/locations/id/%s/forecast .
Dette løste i alle fall problemet hos meg.